### PR TITLE
Version 1.2 with X-Auth-Token header for cookieless usage, solving #6.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN go build -o /go/bin/ambassador-auth-oidc
 
 FROM alpine:3.8
 LABEL org.label-schema.vcs-url="https://github.com/ajmyyra/ambassador-auth-oidc"
+LABEL org.label-schema.version="1.2"
 RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
 RUN addgroup -S auth && adduser -S -G auth auth
 USER auth

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -18,7 +18,7 @@
   version = "v3.2.0"
 
 [[projects]]
-  digest = "1:7c2fd446293ff7799cc496d3446e674ee67902d119f244de645caf95dff1bb98"
+  digest = "1:34a9a60fade37f8009ed4a19e02924198aba3eabfcc120ee5c6002b7de17212d"
   name = "github.com/go-redis/redis"
   packages = [
     ".",
@@ -31,8 +31,8 @@
     "internal/util",
   ]
   pruneopts = "UT"
-  revision = "f3bba01df2026fc865f7782948845db9cf44cf23"
-  version = "v6.14.1"
+  revision = "b3d9bf10f6666b2ee5100a6f3f84f4caf3b4e37d"
+  version = "v6.14.2"
 
 [[projects]]
   digest = "1:97df918963298c287643883209a2c3f642e6593379f97ab400c2a2e219ab647d"
@@ -95,7 +95,7 @@
     "pbkdf2",
   ]
   pruneopts = "UT"
-  revision = "5295e8364332db77d75fce11f1d19c053919a9c9"
+  revision = "e84da0312774c21d64ee2317962ef669b27ffb41"
 
 [[projects]]
   branch = "master"
@@ -106,18 +106,18 @@
     "context/ctxhttp",
   ]
   pruneopts = "UT"
-  revision = "4dfa2610cdf3b287375bbba5b8f2a14d3b01d8de"
+  revision = "9b4f9f5ad5197c79fd623a3638e70d8b26cef344"
 
 [[projects]]
   branch = "master"
-  digest = "1:363b547c971a2b07474c598b6e9ebcb238d556d8a27f37b3895ad20cd50e7281"
+  digest = "1:1bce229fad01cbad9bd00e70ca32afff25ac2cea3dd710d50f88c967c1c3df65"
   name = "golang.org/x/oauth2"
   packages = [
     ".",
     "internal",
   ]
   pruneopts = "UT"
-  revision = "d2e6202438beef2727060aa7cabdd924d92ebfd9"
+  revision = "9dcd33a902f40452422c2367fefcb95b54f9f8f8"
 
 [[projects]]
   digest = "1:6247f76e55a1e1a5c19a81e2d4b4dff6730461eeb5bbb0a16dd4a8ec8637ee93"

--- a/README.md
+++ b/README.md
@@ -32,15 +32,17 @@ Following environment variables are used by the software.
 
 ## Usage
 
-All (except the Kubernetes one) expect that you've cloned the code into your own Go environment (for example, to $GOPATH/src/github.com/ajmyyra/ambassador-auth-oidc)
+All (except the Kubernetes one) expect that you've cloned the code into your own Go environment (for example, to $GOPATH/src/github.com/ajmyyra/ambassador-auth-oidc).
+
+On browser-side, AuthProxy sets up a cookie named "auth" when redirecting the browser back to the original resource. After login, requests are allowed through by either with a cookie or by setting `X-Auth-Token` header in the request. Token is a JSON Web Token that can be fetched from the "auth" cookie through `document.cookie` in DOM.
 
 ### As binary
-
-Fetch dependencies, build the binary and run it.
+Start by cloning the code into your own Go environment (for example, to $GOPATH/src/github.com/ajmyyra/ambassador-auth-oidc). Fetch dependencies, build the binary and run it.
 
 ```
 cd /path/to/code
-go get ./...
+go get github.com/golang/dep/cmd/dep
+$GOPATH/bin/dep ensure
 go build
 ./ambassador-auth-oidc
 ```
@@ -50,7 +52,7 @@ go build
 Start the container with `docker run`.
 
 ```
-docker run -p 8080:8080 -e OIDC_PROVIDER="https://your-oidc-provider/" -e SELF_URL="http://your-server.com:8080" -e OIDC_SCOPES="profile email" -e CLIENT_ID="YOUR_CLIENT_ID" -e CLIENT_SECRET="YOUR_CLIENT_SECRET" -e REDIS_ADDRESS="redis:6379" -e REDIS_PASSWORD="YOUR_REDIS_PASSWORD" ajmyyra/ambassador-auth-oidc:1.1
+docker run -p 8080:8080 -e OIDC_PROVIDER="https://your-oidc-provider/" -e SELF_URL="http://your-server.com:8080" -e OIDC_SCOPES="profile email" -e CLIENT_ID="YOUR_CLIENT_ID" -e CLIENT_SECRET="YOUR_CLIENT_SECRET" -e REDIS_ADDRESS="redis:6379" -e REDIS_PASSWORD="YOUR_REDIS_PASSWORD" ajmyyra/ambassador-auth-oidc:1.2
 ```
 
 ### With Ambassador in Kubernetes

--- a/auth_test.go
+++ b/auth_test.go
@@ -22,7 +22,8 @@ func TestTokenBlacklisting(t *testing.T) {
 	var testdomain = "testing.com"
 	var userinfo = []byte("testfoo1234567890")
 	var expiration = time.Now().Add(time.Hour)
-	testCookie := createCookie(userinfo, expiration, testdomain)
+	testJwt := createSignedJWT(userinfo, expiration)
+	testCookie := createCookie(testJwt, expiration, testdomain)
 
 	token, err := parseJWT(testCookie.Value)
 	if err != nil {

--- a/login_test.go
+++ b/login_test.go
@@ -18,7 +18,8 @@ func TestCookieCreation(t *testing.T) {
 	var testdomain = "testing.com"
 	var userinfo = []byte("testfoo1234567890")
 	var expiration = time.Now().Add(time.Hour)
-	testCookie := createCookie(userinfo, expiration, testdomain)
+	testJwt := createSignedJWT(userinfo, expiration)
+	testCookie := createCookie(testJwt, expiration, testdomain)
 
 	if testCookie.Domain != testdomain {
 		t.Error("Expected cookie domain to be " + testdomain + ", got " + testCookie.Domain + "instead.")

--- a/misc/auth-deployment.yaml.example
+++ b/misc/auth-deployment.yaml.example
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: oidc-auth
-        image: ajmyyra/ambassador-auth-oidc:1.1
+        image: ajmyyra/ambassador-auth-oidc:1.2
         imagePullPolicy: Always
         ports:
         - name: http-api


### PR DESCRIPTION
Version 1.2 adds the possibility to access protected resources by using the X-Auth-Token header in requests, without the cookie.

As last step in authentication is the redirect, it isn't possible to return JWT in response header including the cookie, but it can be fetched from `document.cookie` under the name "auth".