### PR TITLE
Fix redirect 0.50

### DIFF
--- a/misc/auth-deployment.yaml.example
+++ b/misc/auth-deployment.yaml.example
@@ -22,6 +22,8 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: oidc-auth
     spec:
@@ -39,6 +41,8 @@ spec:
             value: "localhost:6379"
           - name: OIDC_SCOPES
             value: "profile email"
+          - name: SKIP_AUTH_URI
+            value: "/httpbin/ip"
           - name: JWT_HMAC_SECRET
             valueFrom:
               secretKeyRef:

--- a/misc/auth-deployment.yaml.example
+++ b/misc/auth-deployment.yaml.example
@@ -41,8 +41,6 @@ spec:
             value: "localhost:6379"
           - name: OIDC_SCOPES
             value: "profile email"
-          - name: SKIP_AUTH_URI
-            value: "/httpbin/ip"
           - name: JWT_HMAC_SECRET
             valueFrom:
               secretKeyRef:

--- a/misc/auth-service.yaml.example
+++ b/misc/auth-service.yaml.example
@@ -12,6 +12,12 @@ metadata:
       auth_service: "oidc-auth:8080"
       allowed_headers:
       - "X-Auth-Userinfo"
+      ---
+      apiVersion: ambassador/v0
+      kind:  Mapping
+      name:  login_mapping
+      prefix: /login/
+      service: oidc-auth:8080
 spec:
   type: ClusterIP
   selector:


### PR DESCRIPTION
Added a mapping for ambassador to redirect /login url to oidc-auth:8080 pod due to bug introduced in ambassador 0.50.x versions. 
